### PR TITLE
Update asus_t100ta.mk

### DIFF
--- a/asus_t100ta/asus_t100ta.mk
+++ b/asus_t100ta/asus_t100ta.mk
@@ -28,3 +28,9 @@ PRODUCT_RESTRICT_VENDOR_FILES := false
 
 PRODUCT_AAPT_CONFIG := normal large mdpi tvdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := mdpi
+
+# Downstepping to 32-bit build
+# T100TA supports 64-bit but Wi-Fi on Lollipop is fails to load BRCM Wi-Fi firmware
+# Forcing 32-bit mode resolves this
+TARGET_KERNEL_ARCH := x86
+TARGET_CPU_VARIANT := x86

--- a/asus_t100ta/asus_t100ta.mk
+++ b/asus_t100ta/asus_t100ta.mk
@@ -29,8 +29,6 @@ PRODUCT_RESTRICT_VENDOR_FILES := false
 PRODUCT_AAPT_CONFIG := normal large mdpi tvdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := mdpi
 
-# Downstepping to 32-bit build
-# T100TA supports 64-bit but Wi-Fi on Lollipop is fails to load BRCM Wi-Fi firmware
-# Forcing 32-bit mode resolves this
-TARGET_KERNEL_ARCH := x86
-TARGET_CPU_VARIANT := x86
+# Downstepping to 32-bit build for debug
+# TARGET_KERNEL_ARCH := x86
+# TARGET_CPU_VARIANT := x86


### PR DESCRIPTION
Forcing to 32-bit to fix Wi-Fi for Lollipop. This change will spread to other BYT build targets with BCM (and possibly Marvell) later today. RTL should be okay at 64-bit but will test anyways.
